### PR TITLE
Link to the actual CLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # clabot-config
 Adding a GitHub CLA Bot for Hackathons and future open-source projects
 
-The .clabot config file is the setup for the cla-bot. The contributors property contains a list of all the GitHub handles that are cla-signed, whether an internal or external contributor.
+The .clabot config file is the setup for the cla-bot. The contributors property contains a list of all the GitHub handles that are [cla-signed](https://docs.google.com/forms/d/e/1FAIpQLSfxy_9WJptKeTmTsrQ6C-5JeiVs4i1pUiahzgLZta1t6Nls-g/formResponse), whether an internal or external contributor.
+


### PR DESCRIPTION
It feels weird to have a list of users in this repo without having at least a link to the actual license. 