### PR TITLE
Add subhash686 to clabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -241,6 +241,7 @@
     "stephzabala",
     "st0nebraker",
     "Strum355",
+    "subhash686",
     "suki-randhawa1",
     "superhsu",
     "tamarj0y",


### PR DESCRIPTION
I signed the CLA and noticed that the new proposed workflow is to let contributors make a clabot PR that a sourcegraph team member will approve.

Thanks!