### PR TITLE
doc: document the service account and the access it requires

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 # tools
 
-The [`.clabot`](.clabot) config file is the setup for the [cla-bot](https://colineberhardt.github.io/cla-bot/).
+The [`.clabot`](../.clabot) config file is the setup for the [cla-bot](https://colineberhardt.github.io/cla-bot/).
 The contributors property contains a list of all the GitHub handles that are have signed the CLA, whether the user is an internal or external contributor.
 
 Sourcegraph teammates can find the signed responses in [this spreadsheet](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit#gid=1678726755), and edit the form [here](https://docs.google.com/forms/d/18Rd5caKejbk6ATTy-znjZofhKKeGS2AfxbsKoKFaXL8/edit).
@@ -10,6 +10,7 @@ Sourcegraph teammates can find the signed responses in [this spreadsheet](https:
 Credentials should be a GCP service account with at least read access to Google Forms resources.
 
 The path to the key should be set to `GOOGLE_APPLICATION_CREDENTIALS`. For the GitHub Action, set the key to `CLABOT_CREDENTIALS` in the Secrets tab by encoding it in base64, e.g. `cat $GOOGLE_APPLICATION_CREDENTIALS | base64`.
+The service account currently in use is [clabot](https://console.cloud.google.com/iam-admin/serviceaccounts/details/clabot@sourcegraph-ci.iam.gserviceaccount.com?project=sourcegraph-ci) - it must have access to the spreadsheets noted above.
 
 You can manually sync contributors in an *additive* manner with the `sync` command:
 


### PR DESCRIPTION
The sync action has been broken, presumably because service accounts were removed from drive as a result of the sourcegraph.com domain restriction. Request to reinstate access: https://sourcegraph.slack.com/archives/C01CSS3TC75/p1660672690101049

This PR adds docs indicating what is required