### PR TITLE
Fix renovate bot name in .clabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -287,7 +287,7 @@
     "rebeccadee",
     "redhoyasa",
     "renatolabs",
-    "renovate-bot",
+    "renovate[bot]",
     "rhiam",
     "rmmh",
     "rrhyne",


### PR DESCRIPTION
Lots of PRs opened by the Renovate bot that are flagged as not having signed the CLA: https://github.com/sourcegraph/sourcegraph/pulls/app%2Frenovate

Example PR https://github.com/sourcegraph/sourcegraph/pull/46049
And its cla-bot logs https://s3.amazonaws.com/cla-bot-logs/sourcegraph-d4a718c5-7408-452d-a755-294cd1dd1e43

Shows the correct name is `renovate[bot]`

This may not be the correct way to update the CLA list, but perhaps it gives enough of a pointer to how to fix it properly?