### PR TITLE
report failures when clabot-config fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,3 +15,9 @@ jobs:
       # Runs a single command using the runners shell
       - name: Validate if .clabot is valid JSON
         run: cat .clabot | jq
+
+  report_failure:
+    needs: check
+    if: ${{ failure() }}
+    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,3 +42,9 @@ jobs:
             git commit -am "clabot: sync contributors that have signed the CLA"
             git push
           fi
+
+  report_failure:
+    needs: sync
+    if: ${{ failure() }}
+    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    secrets: inherit


### PR DESCRIPTION
Ensure that when the actions in this repo fails we get alerted

### Test plan
previously tested on sourcegraph/sourcegraph repo