### PR TITLE
docs: fix link to accepting external contributions guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains configuration and tooling for managing Contributor Lice
 To sign the Sourcegraph CLA, please fill out [this form](https://forms.gle/YnmetmopXNxFxsDUA).
 You can also find the full text of the CLA [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/CLA.txt).
 
-Sourcegraph teammates can refer to the [accepting external contributions guide](https://docs.sourcegraph.com/dev/contributing/accepting_contribution).
+Sourcegraph teammates can refer to the [accepting external contributions guide](https://sourcegraph.com/docs/dev/contributing/accepting_contribution).
 
 ## Manual operation
 


### PR DESCRIPTION
Replace link to old docs with link to new docs.