### PR TITLE
chore: remove usage of monorepo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,3 @@ jobs:
       # Runs a single command using the runners shell
       - name: Validate if .clabot is valid JSON
         run: cat .clabot | jq
-
-  report_failure:
-    needs: check
-    if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
-    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 This repository contains configuration and tooling for managing Contributor License Agreements (CLAs) for all contributors to [Sourcegraph](https://about.sourcegraph.com/).
 
 To sign the Sourcegraph CLA, please fill out [this form](https://forms.gle/YnmetmopXNxFxsDUA).
-You can also find the full text of the CLA [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/CLA.txt).
 
 Sourcegraph teammates can refer to the [accepting external contributions guide](https://sourcegraph.com/docs/dev/contributing/accepting_contribution).
 


### PR DESCRIPTION
Monorepo just went private. Checked about the CLA link https://sourcegraph.slack.com/archives/C023BV511TR/p1724083602678739?thread_ts=1724083088.123729&cid=C023BV511TR , sounds like it's no longer needed