### PR TITLE
trim github handles of leading and trailing whitespace

### DIFF
--- a/internal/responses/responses.go
+++ b/internal/responses/responses.go
@@ -118,5 +118,5 @@ func cleanGitHubHandle(handle string) string {
 	handle = strings.TrimPrefix(handle, "@")
 	// If a full URL is provided
 	handle = strings.TrimPrefix(handle, "https://github.com/")
-	return handle
+	return strings.TrimSpace(handle)
 }


### PR DESCRIPTION
on occassion people put their usernames in a rush and accidentally add spaces, which confuses dear Clabot and causes it to not find the persons username leading to anarchy. 

To stop the user uprising against clabots, we trim the github handles now